### PR TITLE
Fix broken synchronization in getCodeLenses

### DIFF
--- a/server/src/som/langserv/newspeak/NewspeakAdapter.java
+++ b/server/src/som/langserv/newspeak/NewspeakAdapter.java
@@ -435,24 +435,14 @@ public class NewspeakAdapter extends LanguageAdapter<NewspeakStructures> {
   }
 
   @Override
-  public void getCodeLenses(final List<CodeLens> codeLenses,
-      final String documentUri) {
-    String path;
-    try {
-      path = docUriToNormalizedPath(documentUri);
-    } catch (URISyntaxException e) {
+  public void getCodeLenses(final List<CodeLens> codeLenses, final String documentUri) {
+    NewspeakStructures probe = getProbe(documentUri);
+    if (probe == null) {
       return;
     }
 
-    NewspeakStructures probe;
-    synchronized (path) {
-      probe = structuralProbes.get(path);
-    }
-
-    if (probe != null) {
-      for (MixinDefinition c : probe.getClasses()) {
-        Minitest.checkForTests(c, codeLenses, documentUri);
-      }
+    for (MixinDefinition c : probe.getClasses()) {
+      Minitest.checkForTests(c, codeLenses, documentUri);
     }
   }
 }


### PR DESCRIPTION
Instead of synchronizing on the path, which is not guaranteed to be the same object, use `getProbe()` which should already do the correct synchronization. It also normalizes the path already for us.

@HumphreyHCB please have a look. If this looks good to you, would be great if you could mark this pull request as reviewed.