### PR TITLE
Fix WebSocket connection to unbreak debugger in VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,6 @@
 		"vscode-languageclient": "7.0.0",
 		"@vscode/debugprotocol": "1.55.1",
 		"@vscode/debugadapter": "1.55.1",
-		"ws": "8.5.0"
+		"ws": "8.8.1"
 	}
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -150,7 +150,7 @@ class SomDebugSession extends DebugSession {
 
   private connectDebugger(response: DebugProtocol.Response, ports: {msg: number, trace: number}): void {
     this.socket = new WebSocket('ws://localhost:' + ports.msg);
-    new WebSocket('ws://localhost:' + ":" + ports.trace);
+    new WebSocket('ws://localhost:' + ports.trace);
 
     this.socket.on('open', () => {
       this.sendInitialBreakpoints();


### PR DESCRIPTION
This fixes a typo in the tracing socket URL, and updates the WebSocket NPM package.