### PR TITLE
running the debugger on an open SOMns file now runs SOMns with that file

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -7,8 +7,6 @@ import { BreakpointEvent, DebugSession, Handles, InitializedEvent, Scope,
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as WebSocket from 'ws';
 
-
-
 import { BreakpointData, Source as WDSource, Respond,
   InitializeConnection, SourceMessage, IdMap, StoppedMessage,
   StackTraceResponse, StackTraceRequest, ScopesRequest, ScopesResponse,
@@ -16,7 +14,6 @@ import { BreakpointData, Source as WDSource, Respond,
   createLineBreakpointData,
   InitializationResponse} from './messages';
 import { determinePorts } from "./launch-connector";
-
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   /** Path to the main program */
@@ -48,8 +45,6 @@ interface BreakpointPair {
   vs:  DebugProtocol.Breakpoint;
   som: BreakpointData;
 }
-
-
 
 class SomDebugSession extends DebugSession {
   private socket: WebSocket;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -7,6 +7,8 @@ import { BreakpointEvent, DebugSession, Handles, InitializedEvent, Scope,
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as WebSocket from 'ws';
 
+
+
 import { BreakpointData, Source as WDSource, Respond,
   InitializeConnection, SourceMessage, IdMap, StoppedMessage,
   StackTraceResponse, StackTraceRequest, ScopesRequest, ScopesResponse,
@@ -14,6 +16,7 @@ import { BreakpointData, Source as WDSource, Respond,
   createLineBreakpointData,
   InitializationResponse} from './messages';
 import { determinePorts } from "./launch-connector";
+
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   /** Path to the main program */
@@ -45,6 +48,8 @@ interface BreakpointPair {
   vs:  DebugProtocol.Breakpoint;
   som: BreakpointData;
 }
+
+
 
 class SomDebugSession extends DebugSession {
   private socket: WebSocket;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,6 @@ import { Socket } from 'net';
 import { workspace, ExtensionContext, window, debug, DebugConfigurationProvider, WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo } from 'vscode-languageclient/node';
 
-
 const LSPort = 8123;  // TODO: make configurable
 const EnableExtensionDebugging : boolean = <boolean> workspace.getConfiguration('somns').get('debugMode');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,9 @@
 import { ChildProcess, spawn } from 'child_process';
 import { Socket } from 'net';
 
-import { workspace, ExtensionContext, window } from 'vscode';
+import { workspace, ExtensionContext, window, debug, DebugConfigurationProvider, WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo } from 'vscode-languageclient/node';
-import * as vscode from 'vscode';
+
 
 const LSPort = 8123;  // TODO: make configurable
 const EnableExtensionDebugging : boolean = <boolean> workspace.getConfiguration('somns').get('debugMode');
@@ -160,7 +160,7 @@ export function activate(context: ExtensionContext) {
 	}
 
 	// Registering the configuration provider for starting opened file
-	vscode.debug.registerDebugConfigurationProvider('SOMns', new SOMnsConfigurationProvider)
+	debug.registerDebugConfigurationProvider('SOMns', new SOMnsConfigurationProvider)
 
 	// Create the language client and start the client.
 	client = new LanguageClient('SOMns Language Server', createLSPServer, CLIENT_OPTION);
@@ -181,13 +181,13 @@ export function deactivate(): Thenable<void> | undefined {
 /**
  * This SOMnsConfigurationProvider is a dynamic provider that can change the debug configuration parameters
  */
-class SOMnsConfigurationProvider implements vscode.DebugConfigurationProvider {
+class SOMnsConfigurationProvider implements DebugConfigurationProvider {
 
 	/** Resolve the debug configuration to debug currently selected file */
-	resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+	resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
 
 		// retrieve the active file, if it is a SOMns file then substitute the program variable with the file path
-		const editor = vscode.window.activeTextEditor;
+		const editor = window.activeTextEditor;
 		if (editor && editor.document.languageId === 'SOMns') {
 			config.program = '${file}';
 			config.stopOnEntry = true;


### PR DESCRIPTION
This PR adds support for simply clicking the run-button on a file, and VScode then automatically adapting the debugger configuration.