### PR TITLE
Make Java configurable and report and error if Java 17 was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Not Started]
 
- -
+ - changed config to be in `els` namespace, so `els.debugMode`
 
 ## [0.8.0] - Effortless Language Servers
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+title: Effortless Language Servers Framework
+message: >-
+  If you use or build on this framework, please cite
+  it using the metadata from this file.
+type: software
+authors:
+  - given-names: Stefan
+    family-names: Marr
+    affiliation: University of Kent
+    orcid: 'https://orcid.org/0000-0001-9059-5180'
+    email: s.marr@kent.ac.uk
+  - given-names: Humphrey
+    family-names: Burchell
+    email: h.burchell@kent.ac.uk
+    affiliation: University of Kent
+    orcid: 'https://orcid.org/0000-0003-4728-5819'
+repository-code: >-
+  https://github.com/smarr/effortless-language-servers
+url: >-
+  https://stefan-marr.de/papers/dls-marr-et-al-execution-vs-parse-based-language-servers/
+license: MIT
+date-released: '2022-11-03'

--- a/README.md
+++ b/README.md
@@ -102,9 +102,16 @@ add the following to your VS Code User Settings:
 The server can also be started from the command line:
 
 ```bash
-cd /$pathToCheckout/SOMns-vscode/server
-./run.sh # executes the server, the console will show all communication
+npm run create-server-shell-script
+out/server/start.sh
 ```
+
+This will run the server exactly as VScode would run it.
+In this mode it will accept communication from stdin.
+To configure it for use with TCP, see the `create-server-shell-script`
+script in `package.json`. It currently configure the generated script
+to disable the debugging mode and TCP, which can be enable individually
+by changing the corresponding `false` in the script.
 
 ## Debugging the Debugger Adapter
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To instruct VS code to use an already running instance of the language server,
 add the following to your VS Code User Settings:
 
 ```JavaScript
-"somns.debugMode" : true
+"els.debugMode" : true
 ```
 
 The server can also be started from the command line:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"readme": "This plugin provides support for many common IDE features.",
 	"author": "Stefan Marr",
 	"license": "MIT",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"publisher": "MetaConcProject",
 	"engines": {
 		"vscode": "^1.66.0"
@@ -85,6 +85,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enables debug mode for the extension, language server, and debug adapter. This is only used to develop the SOMns extension."
+				},
+				"els.javaHome": {
+					"type": "string",
+					"default": null,
+					"description": "Path to the Java 17 or later installation. On macOS, it might be /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home. On Linux perhaps /usr/lib/jvm/java-17-openjdk-amd64"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
 			}
 		],
 		"configuration": {
-			"title": "SOMns configuration",
+			"title": "Effortless Language Servers Configuration",
 			"properties": {
-				"somns.debugMode": {
+				"els.debugMode": {
 					"type": "boolean",
 					"default": false,
 					"description": "Enables debug mode for the extension, language server, and debug adapter. This is only used to develop the SOMns extension."

--- a/src/command-line.ts
+++ b/src/command-line.ts
@@ -61,3 +61,22 @@ SCRIPT_DIR=$(dirname $0)
 pushd $\{SCRIPT_DIR\}/../../ > /dev/null
 exec ${cmd.command} '${cmd.args.join("' '")}'`
 }
+
+export function getMajorVersionFromJavaVersionString(version: string): string {
+	const lines = version.split("\n");
+	const partsOfFirstLine = lines[0].split(" ");
+	partsOfFirstLine.shift(); // remove the java name
+
+	// remove the version keyword, if it's there
+	if (partsOfFirstLine[0] === "version") {
+		partsOfFirstLine.shift();
+	}
+
+	// now the first bit should be the version number, maybe with quotes around it
+	let versionNumber = partsOfFirstLine[0];
+	versionNumber = versionNumber.replace(/"/g, ''); // replace the quotes
+
+	const versionParts = versionNumber.split('.');
+
+	return versionParts[0]; // return the major version part
+}

--- a/src/command-line.ts
+++ b/src/command-line.ts
@@ -55,7 +55,7 @@ export function getCommandLine(asAbsolutePath: (string) => string,
 }
 
 export function getShellScript(enableDebug: boolean, enableTcp: boolean) {
-  const cmd = getCommandLine((p) => p, false, false);
+  const cmd = getCommandLine((p) => p, enableDebug, enableTcp);
   return `#!/bin/bash
 SCRIPT_DIR=$(dirname $0)
 pushd $\{SCRIPT_DIR\}/../../ > /dev/null

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo } from
 import { getCommandLine } from './command-line';
 
 const LSPort = 8123;  // TODO: make configurable
-const EnableExtensionDebugging : boolean = <boolean> workspace.getConfiguration('somns').get('debugMode');
+const EnableExtensionDebugging : boolean = <boolean> workspace.getConfiguration('els').get('debugMode');
 
 export const CLIENT_OPTION: LanguageClientOptions = {
 	documentSelector: ['SOMns', 'SOM','simple']

--- a/test/java.test.ts
+++ b/test/java.test.ts
@@ -1,0 +1,65 @@
+import { getMajorVersionFromJavaVersionString } from "../src/command-line";
+import { expect } from "chai";
+
+describe("Java Detection Tests", () => {
+
+  const javaVersionOutput = [
+    {
+      major: "17",
+      string: `openjdk 17.0.3 2022-04-19
+              OpenJDK Runtime Environment Temurin-17.0.3+7 (build 17.0.3+7)
+              OpenJDK 64-Bit Server VM Temurin-17.0.3+7 (build 17.0.3+7, mixed mode, sharing)`
+    },
+    {
+      major: "1",
+      string: `java version "1.8.0_311"
+              Java(TM) SE Runtime Environment (build 1.8.0_311-b11)
+              Java HotSpot(TM) 64-Bit Server VM (build 25.311-b11, mixed mode)`
+    },
+    {
+      major: "17",
+      string: `java version "17.0.2" 2022-01-18 LTS
+              Java(TM) SE Runtime Environment GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05)
+              Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05, mixed mode, sharing)`
+    },
+    {
+      major: "11",
+      string: `java version "11.0.13" 2021-10-19 LTS
+              Java(TM) SE Runtime Environment 18.9 (build 11.0.13+10-LTS-370)
+              Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.13+10-LTS-370, mixed mode)`
+    },
+    {
+      major: "11",
+      string: `openjdk version "11.0.15" 2022-04-19
+              OpenJDK Runtime Environment Temurin-11.0.15+10 (build 11.0.15+10)
+              OpenJDK 64-Bit Server VM Temurin-11.0.15+10 (build 11.0.15+10, mixed mode)`
+    },
+    {
+      major: "17",
+      string: `openjdk version "17.0.3" 2022-04-19
+              OpenJDK Runtime Environment Temurin-17.0.3+7 (build 17.0.3+7)
+              OpenJDK 64-Bit Server VM Temurin-17.0.3+7 (build 17.0.3+7, mixed mode, sharing)`
+    },
+    {
+      major: "17",
+      string: `java version "17.0.2" 2022-01-18 LTS
+              Java(TM) SE Runtime Environment GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05)
+              Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05, mixed mode, sharing)`
+    },
+    {
+      major: "17",
+      string: `java 17.0.2 2022-01-18 LTS
+              Java(TM) SE Runtime Environment GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05)
+              Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.0.0.2 (build 17.0.2+8-LTS-jvmci-22.0-b05, mixed mode, sharing)`
+    }
+  ];
+
+  describe("Java version detection", () => {
+    it("should detected the expected major version from the version string", () => {
+      for (const v of javaVersionOutput) {
+        const major = getMajorVersionFromJavaVersionString(v.string);
+        expect(major).to.equal(v.major);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Also:
 - a CITATION.cff file
 - change the configuration namespace to `els` as shorthand for effortless language servers
 - Update the README about how to start the LS from the command line
