### PR TITLE
Live updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+	
+		"terminal.integrated.shellArgs.linux": [
+		  "-i"
+		],
+	
 	"files.exclude": {
 		"out": false // set this to true to hide the "out" folder with the compiled JS files
 	},

--- a/package.json
+++ b/package.json
@@ -143,6 +143,8 @@
 							}
 						}
 					},
+
+
 					"attach": {
 						"required": [
 							"msgPort",
@@ -173,12 +175,23 @@
 						"stopOnEntry": false
 					},
 					{
+						"name": "Launch and Debug Interpreter",
+						"type": "SOMns",
+						"request": "launch",
+						"program": "${workspaceRoot}/Application.ns",
+						"cwd": "${workspaceRoot}",
+						"runtime": "PLEASE ENTER PATH TO `som` launcher",
+						"runtimeArgs": ["-d"],
+						"stopOnEntry": false
+					},
+					{
 						"name": "Attach to SOM program",
 						"type": "SOMns",
 						"request": "attach",
 						"msgPort": 7977,
 						"tracePort": 7978
 					}
+					
 				]
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -181,7 +181,14 @@
 					}
 				]
 			}
-		]
+		],
+
+		"commands": [
+			{
+			  "command": "updateFile",
+			  "title": "Update Class"
+			}
+		  ]
 	},
 	"scripts": {
 		"compile:server": "cd server && ant -e deploy",

--- a/src/asyncTraceProvider.ts
+++ b/src/asyncTraceProvider.ts
@@ -1,0 +1,4 @@
+import {TreeItem, TreeItemCollapsibleState, TreeDataProvider, Event, ProviderResult, EventEmitter, CancellationToken} from 'vscode'
+
+import {StackFrame} from './messages'
+

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -231,6 +231,9 @@ class SomDebugSession extends DebugSession {
       case "SymbolMessage":
         // Not necessary to know symbols at the moment
         break;
+      case "resumeActorResponse":
+        // Currently causing error, but not supported yet
+        break;
       default:
         this.sendEvent(new OutputEvent("[didn't understand msg] " + event.data, 'dbg-adapter'));
     }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -342,10 +342,10 @@ class SomDebugSession extends DebugSession {
     const frames = [];
     for (let frame of data.stackFrames) {
       if (frame.sourceUri) {
-        frames.push(new StackFrame(frame.id, frame.frameId, frame.name,
+        frames.push(new StackFrame(frame.id, frame.name,
           this.vsSourceFromUri(frame.sourceUri), frame.line, frame.column));
       } else {
-        frames.push(new StackFrame(frame.id, frame.frameId, frame.name))
+        frames.push(new StackFrame(frame.id, frame.name))
       }
     }
 
@@ -353,7 +353,6 @@ class SomDebugSession extends DebugSession {
       stackFrames: frames,
       totalFrames: data.totalFrames
     };
-    1/0;
     this.sendResponse(ideResponse);
   }
 
@@ -462,9 +461,8 @@ class SomDebugSession extends DebugSession {
   protected restartFrameRequest(response: DebugProtocol.RestartFrameResponse, args: DebugProtocol.RestartFrameArguments, request?: DebugProtocol.Request): void {
     const message: RestartFrame = {
       action: "RestartFrame",
-       frameId: args.frameId
+       frameId: request.arguments.frameId
     };
-    console.log(`Restarting at frame id '${args.frameId}'`)
     this.send(message);
   }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -12,7 +12,7 @@ import { BreakpointData, Source as WDSource, Respond,
   StackTraceResponse, StackTraceRequest, ScopesRequest, ScopesResponse,
   StepMessage, VariablesRequest, VariablesResponse,
   createLineBreakpointData, InitializationResponse} from './messages';
-import {UpdateClass, RestartFrame , Message} from './extension-messages'
+import {UpdateClass, RestartFrame, EvaluateExpressionRequest, Message} from './extension-messages'
 import { determinePorts } from "./launch-connector";
 import { writeFileSync } from 'fs';
 import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
@@ -79,7 +79,6 @@ class SomDebugSession extends DebugSession {
   private /* readonly */ activityTypes: string[];
   private /* readonly */ knownActivities: Map<number, DebugProtocol.Thread>;
 
-  public asyncStackViewProvider? : AsyncStackViewProvider;
 
   public constructor() {
     super();

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -13,8 +13,21 @@ import { BreakpointData, Source as WDSource, Respond,
   StepMessage, VariablesRequest, VariablesResponse,
   createLineBreakpointData,
   InitializationResponse,
-  UpdateClass, RestartFrame} from './messages';
+  UpdateClass, RestartFrame, EvaluateExpressionRequest, StackFrame as SFM} from './messages';
+
+
+
 import { determinePorts } from "./launch-connector";
+import { writeFileSync } from 'fs';
+import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
+import { networkInterfaces } from 'os';
+//import { window , CancellationToken, Event, TreeDataProvider, TreeItem, ProviderResult } from 'vscode';
+import { VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
+import { getVSCodeDownloadUrl } from '@vscode/test-electron/out/util';
+import { normalize } from 'path';
+import { Breakpoint, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { AsyncStackViewProvider } from './extension';
+
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   /** Path to the main program */
@@ -42,6 +55,58 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
   tracePort: number;
 }
 
+
+
+// class AsyncStackViewProvider implements TreeDataProvider<StackFrameTreeItem> {
+//   onDidChangeTreeData?: Event<void | StackFrameTreeItem | StackFrameTreeItem[]>;
+//   getTreeItem(element: StackFrameTreeItem): TreeItem | Thenable<TreeItem> {
+//     return element;
+//   }
+//   getChildren(element?: StackFrameTreeItem): ProviderResult<StackFrameTreeItem[]> {
+//     if (element.children){
+//       return element.children;
+//     }
+//     if (element.innerStack){
+//       return element.innerStack;
+//     }
+//   }
+//   getParent?(element: StackFrameTreeItem): ProviderResult<StackFrameTreeItem> {
+//     throw new Error('Method not implemented.');
+//   }
+//   resolveTreeItem?(item: TreeItem, element: StackFrameTreeItem, token: CancellationToken): ProviderResult<TreeItem> {
+//     throw new Error('Method not implemented.');
+//   }
+// }
+
+
+// class AsyncStackFrameTreeItem extends TreeItem {
+//     // public children : StackFrameTreeItem[];
+//     // public innerStack: StackFrameTreeItem[];
+  
+  
+//     // constructor(stackFrame: SFM, innerStack?: AsyncStackFrameTreeItem[]) {
+//     //   super(stackFrame.name);
+//     //  if(innerStack){
+//     //     super("Parallel Stack");
+//     //     this.innerStack = innerStack;
+//     //  } else {
+  
+//     //   // var isParallel = stackFrame.parallelStacks == null;
+//     //   // super(stackFrame.name);
+//     //   // if (isParallel) {
+//     //   //   this.children = stackFrame.parallelStacks.map( (fullStack : SFM[]) => {
+//     //   //     var internalFrames = fullStack.map( singleFrame => new StackFrameTreeItem(singleFrame));
+//     //   //     return new StackFrameTreeItem(null,internalFrames);
+//     //   //   } )
+//     //   //     //  this.children = stackFrame.parallelStacks.map((fullStack : StackFrameMessage[])=> {
+//     //   //     //     return fullStack.map((singleFrame : StackFrameMessage) => {
+//     //   //     //       return new StackFrameTreeItem(singleFrame);
+//     //   //     //     })        
+//     //   //     //  })
+//     //  } 
+// //  }
+//   }
+
 interface BreakpointPair {
   vs:  DebugProtocol.Breakpoint;
   som: BreakpointData;
@@ -61,8 +126,17 @@ class SomDebugSession extends DebugSession {
 
   private varHandles : Handles<string>;
 
+  
+  private log = "/Users/matteo/TruffleStuff/SOMns-vscode/src/log.txt";
+
+  private addToLog(text : string) {
+    writeFileSync(this.log,text,{flag:'a+'})
+  }
+
   private /* readonly */ activityTypes: string[];
   private /* readonly */ knownActivities: Map<number, DebugProtocol.Thread>;
+
+  public asyncStackViewProvider? : AsyncStackViewProvider;
 
   public constructor() {
     super();
@@ -107,10 +181,16 @@ class SomDebugSession extends DebugSession {
       args: LaunchRequestArguments): void {
     const options = {cwd: args.cwd};
     //, '-d'
-    let somArgs = ['-G' , '-wd', args.program];
+    // let somArgs = ['-G' , '-wd', args.program];
+    // if (args.runtimeArgs) {
+    //   somArgs = args.runtimeArgs.concat(somArgs);
+    // }
+    debugger
+    let somArgs = ['-G', '-wd']
     if (args.runtimeArgs) {
-      somArgs = args.runtimeArgs.concat(somArgs);
+      somArgs = somArgs.concat(args.runtimeArgs)
     }
+    somArgs = somArgs.concat(args.program)
     if (args.args) {
       somArgs = somArgs.concat(args.args);
     }
@@ -137,6 +217,15 @@ class SomDebugSession extends DebugSession {
     this.somProc.on('close', code => {
       this.sendEvent(new TerminatedEvent());
     })
+   
+    this.addToLog("**************I AM IN THE CONSOLE!************");
+   //var avp = new AsyncStackViewProvider();
+
+    // try{t} catch (e) {
+    //   this.addToLog(`${e}`);
+    // }
+    
+    //window.registerTreeDataProvider("asyncStacksView", this.asyncStackViewProvider);
   }
 
   protected attachRequest(response: DebugProtocol.AttachResponse,
@@ -341,12 +430,16 @@ class SomDebugSession extends DebugSession {
       ideResponse: DebugProtocol.StackTraceResponse) {
     const frames = [];
     for (let frame of data.stackFrames) {
+      if (frame.parallelStacks != null){
+        frames.push(new StackFrame(frame.id, "PARALLEL STACKS: " + frame.parallelStacks.length));
+      } else {
       if (frame.sourceUri) {
         frames.push(new StackFrame(frame.id, frame.name,
           this.vsSourceFromUri(frame.sourceUri), frame.line, frame.column));
       } else {
         frames.push(new StackFrame(frame.id, frame.name))
       }
+    }
     }
 
     ideResponse.body = {
@@ -462,6 +555,16 @@ class SomDebugSession extends DebugSession {
     const message: RestartFrame = {
       action: "RestartFrame",
        frameId: request.arguments.frameId
+    };
+    this.send(message);
+  }
+
+  protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments, request?: DebugProtocol.Request): void {
+    const message: EvaluateExpressionRequest = {
+      action: "EvaluateExpressionRequest",
+       expression: args.expression,
+     
+       frameId: args.frameId
     };
     this.send(message);
   }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -12,8 +12,8 @@ import { BreakpointData, Source as WDSource, Respond,
   StackTraceResponse, StackTraceRequest, ScopesRequest, ScopesResponse,
   StepMessage, VariablesRequest, VariablesResponse,
   createLineBreakpointData,
-  InitializationResponse,
-  UpdateClass, RestartFrame} from './messages';
+  InitializationResponse} from './messages';
+import {UpdateClass, RestartFrame , Message} from './extension-messages'
 import { determinePorts } from "./launch-connector";
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -300,11 +300,12 @@ class SomDebugSession extends DebugSession {
     return id;
   }
 
-  private send(respond: Respond) {
+  private send(respond: Respond | Message) {
     if (this.socket) {
       this.socket.send(JSON.stringify(respond));
     }
   }
+
 
   private sendBreakpoint(bpP: BreakpointPair, connected: boolean): void {
     if (connected) {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -12,7 +12,8 @@ import { BreakpointData, Source as WDSource, Respond,
   StackTraceResponse, StackTraceRequest, ScopesRequest, ScopesResponse,
   StepMessage, VariablesRequest, VariablesResponse,
   createLineBreakpointData,
-  InitializationResponse} from './messages';
+  InitializationResponse,
+  UpdateClass} from './messages';
 import { determinePorts } from "./launch-connector";
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -455,6 +456,27 @@ class SomDebugSession extends DebugSession {
       args: DebugProtocol.PauseArguments): void {
     this.sendStep("stop", response, args);
   }
+
+  protected customRequest(command: string, response: DebugProtocol.Response, args: any): void {
+
+		switch (command) {
+			case 'updateClassRequest':
+				this.updateClassRequest(args);
+				break;
+			default:
+				super.customRequest(command, response, args);
+				break;
+		}
+	}
+
+  protected  updateClassRequest(
+    args: String): void {
+      const message: UpdateClass = {
+        type: "UpdateClass",
+        class: args};
+      this.send(message);
+  }
 }
+
 
 DebugSession.run(SomDebugSession);

--- a/src/extension-messages.ts
+++ b/src/extension-messages.ts
@@ -1,0 +1,15 @@
+import { integer } from "vscode-languageserver-protocol";
+import {Message as OrigMessage} from "./messages";
+
+export type Message = OrigMessage | UpdateClass | RestartFrame
+
+/* This file adds extra messages than the ones defined in extension.ts as that file is a symbolic link to another repository */
+export interface UpdateClass {
+    action: "UpdateClass";
+    classToRecompile: String;
+  }
+
+export interface RestartFrame {
+    action: "RestartFrame";
+    frameId: integer;
+  }

--- a/src/extension-messages.ts
+++ b/src/extension-messages.ts
@@ -1,7 +1,7 @@
 import { integer } from "vscode-languageserver-protocol";
 import {Message as OrigMessage} from "./messages";
 
-export type Message = OrigMessage | UpdateClass | RestartFrame
+export type Message = OrigMessage | UpdateClass | RestartFrame | EvaluateExpressionRequest
 
 /* This file adds extra messages than the ones defined in extension.ts as that file is a symbolic link to another repository */
 export interface UpdateClass {
@@ -13,3 +13,8 @@ export interface RestartFrame {
     action: "RestartFrame";
     frameId: integer;
   }
+export interface EvaluateExpressionRequest {
+  action: "EvaluateExpressionRequest",
+       expression: String,
+       frameId: integer
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,8 +169,6 @@ export function activate(context: ExtensionContext) {
 	// Create the language client and start the client.
 	client = new LanguageClient('SOMns Language Server', createLSPServer, CLIENT_OPTION);
 	client.start();
-	this.asyncStackViewProvider = new AsyncStackViewProvider();
-
 }
 
 export function deactivate(): Thenable<void> | undefined {
@@ -224,52 +222,4 @@ class SOMnsConfigurationProvider implements DebugConfigurationProvider {
 	}
 }
 
-export class AsyncStackViewProvider implements TreeDataProvider<StackFrameTreeItem> {
-	onDidChangeTreeData?: Event<void | StackFrameTreeItem | StackFrameTreeItem[]>;
-	getTreeItem(element: StackFrameTreeItem): TreeItem | Thenable<TreeItem> {
-	  return element;
-	}
-	getChildren(element?: StackFrameTreeItem): ProviderResult<StackFrameTreeItem[]> {
-	  if (element.children){
-		return element.children;
-	  }
-	  if (element.innerStack){
-		return element.innerStack;
-	  }
-	}
-	getParent?(element: StackFrameTreeItem): ProviderResult<StackFrameTreeItem> {
-	  throw new Error('Method not implemented.');
-	}
-	resolveTreeItem?(item: TreeItem, element: StackFrameTreeItem, token: CancellationToken): ProviderResult<TreeItem> {
-	  throw new Error('Method not implemented.');
-	}
-  }
-  
-	
-  export class StackFrameTreeItem extends TreeItem {
-	  public children : StackFrameTreeItem[];
-	  public innerStack: StackFrameTreeItem[];
-	
-	
-	  constructor(stackFrame: StackFrame, innerStack? : StackFrameTreeItem[]) {
-	   if(innerStack){
-		  super("Parallel Stack");
-		  this.innerStack = innerStack;
-	   } else {
-	
-	   var isParallel = stackFrame.parallelStacks == null;
-	   super(stackFrame.name);
-	   if (isParallel) {
-		this.children = stackFrame.parallelStacks.map( (fullStack : StackFrame[]) => {
-		  var internalFrames = fullStack.map( singleFrame => new StackFrameTreeItem(singleFrame));
-		  return new StackFrameTreeItem(null,internalFrames);
-		} )
-		  //  this.children = stackFrame.parallelStacks.map((fullStack : StackFrameMessage[])=> {
-		  //     return fullStack.map((singleFrame : StackFrameMessage) => {
-		  //       return new StackFrameTreeItem(singleFrame);
-		  //     })        
-		  //  })
-	   } 
-	  }}
-	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,11 +185,17 @@ export function deactivate(): Thenable<void> | undefined {
 export function defineCommands(ctx: ExtensionContext) : void {
 	
 	const updateFileHandler = () => {
-		const file : String = window.activeTextEditor.document.uri.toString(true);
+		const file : String = window.activeTextEditor.document.uri.fsPath;
 		debug.activeDebugSession.customRequest('updateClassRequest', file);
 	  };
-
+	  
 	registerCommand('updateFile',updateFileHandler,ctx);
+	
+	// const restartFrameHandler = () => {
+	// 	debug.activeDebugSession.customRequest('restartFrame', debug.activeDebugSession.id);
+	//   };
+
+	// registerCommand('restartFrame',restartFrameHandler,ctx);
 }
 
 function registerCommand(command: string, commandHandler : (any) => any, ctx : ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,13 +183,17 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 export function defineCommands(ctx: ExtensionContext) : void {
+	
 	const updateFileHandler = () => {
-		debug.activeDebugSession.customRequest('updateClassRequest','{$file}');
+		const file : String = window.activeTextEditor.document.uri.toString(true);
+		debug.activeDebugSession.customRequest('updateClassRequest', file);
 	  };
+
 	registerCommand('updateFile',updateFileHandler,ctx);
 }
 
 function registerCommand(command: string, commandHandler : (any) => any, ctx : ExtensionContext) {
+
 	ctx.subscriptions.push(commands.registerCommand(command, commandHandler));
   }
 


### PR DESCRIPTION
@Marmat21 I hope it's ok for you to document this based on your notes:

"""
To support the changes of batches 1 and 2 I did several improvements in the vscode plugin including:
- adding support for executing the open SOMns file
- command for updating class
- button for restarting a certain frame
- various fixes including making breakpoints on promised execution work (part of the async stack traces branch).

Especially in the last weeks, however, I had many problems with the vscode plugin which I report here for completeness of information. Maybe @Stefan when you are back at work you can take a look at it.
The plugin is highly unstable. For example, if you recall, we asked the student to add a tree view for the promise groups to the debugger.
This has to be done through a treeviewprovider (see [here](https://github.com/microsoft/vscode-extension-samples/tree/main/tree-view-sample)). Adding such a provider and trying to do anything from the debugger.ts file makes it so that when you launch a somns program nothing actually happens.
And by nothing, I mean *nothing*. No sort of feedback is given in any of the outputs of the plugin.
This happens to both me and the student, and I have lost hours with other typescript/javascript colleagues to try and debug this, but we did not find a solution.
Also, I do not seem to be able to add a breakpoint in debugger.ts (while they work in extension.ts).
I am totally frustrated with this, and so is the student, so I hope you will be able to find a solution or he will have to move to the IntelliJ plugin.
"""