### PR TITLE
Use VSCode's in-process approach to debugging adapters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,11 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"preLaunchTask": "npm"
+			"preLaunchTask": "npm prerun"
 		},
 		{
 			"name": "Run Debugger as Server",
@@ -36,10 +35,9 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}",
 							 "--extensionTestsPath=${workspaceFolder}/out/test"],
-			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-			// "preLaunchTask": "npm"
+			"preLaunchTask": "npm prerun"
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,20 +15,6 @@
 			"preLaunchTask": "npm prerun"
 		},
 		{
-			"name": "Run Debugger as Server",
-			"type": "node",
-			"request": "launch",
-			"runtimeArgs": [ "--nolazy" ],
-			"program": "${workspaceRoot}/src/debugger.ts",
-			"stopOnEntry": false,
-			"args": [ "--server=4711" ],
-			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceRoot}/out/**/*.js"
-			],
-			"cwd": "${workspaceRoot}"
-		},
-		{
 			"name": "Launch Tests",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,17 @@
 				"_id": "build",
 				"isDefault": false
 			}
+		},
+		{
+			"label": "npm prerun",
+			"type": "shell",
+			"command": "npm",
+			"args": ["run", "prerun"],
+			"problemMatcher": "$tsc-watch",
+			"group": {
+				"_id": "build",
+				"isDefault": false
+			}
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "effortless-language-servers",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "effortless-language-servers",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14,28 +14,28 @@
 				"@vscode/debugprotocol": "1.55.1",
 				"vscode-languageclient": "7.0.0",
 				"vscode-languageserver-protocol": "3.16.0",
-				"ws": "8.8.1"
+				"ws": "8.12.0"
 			},
 			"devDependencies": {
-				"@types/chai": "4.3.3",
-				"@types/mocha": "9.1.1",
-				"@types/node": "18.7.16",
-				"@types/vscode": "1.66.0",
-				"@vscode/test-electron": "2.1.5",
-				"chai": "4.3.6",
-				"esbuild": "^0.15.12",
-				"mocha": "10.0.0",
+				"@types/chai": "4.3.4",
+				"@types/mocha": "10.0.1",
+				"@types/node": "18.11.18",
+				"@types/vscode": "1.74.0",
+				"@vscode/test-electron": "2.2.2",
+				"chai": "4.3.7",
+				"esbuild": "0.17.3",
+				"mocha": "10.2.0",
 				"run-func": "3.0.0",
-				"typescript": "4.8.2"
+				"typescript": "4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.66.0"
+				"vscode": "^1.74.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
-			"integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
+			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
 			"cpu": [
 				"arm"
 			],
@@ -48,10 +48,154 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
+			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
+			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
+			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
+			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
+			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
+			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
+			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
+			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
+			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
-			"integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
+			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
 			"cpu": [
 				"loong64"
 			],
@@ -59,6 +203,182 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
+			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
+			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
+			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
+			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
+			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
+			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
+			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
+			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
+			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -74,33 +394,27 @@
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
 			"dev": true
 		},
 		"node_modules/@types/mocha": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-			"integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+			"integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.16",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-			"integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.66.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
-			"integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
-			"dev": true
-		},
-		"node_modules/@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@vscode/debugadapter": {
@@ -120,9 +434,9 @@
 			"integrity": "sha512-tEOY1KxSACd77JFfoipYvLZdVdrTnXBiVgS7zKDmAQxxmVsKPERB6HOXDijoWi1wUjFx+K7plXCtweX+k5Fc/g=="
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
-			"integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.2.tgz",
+			"integrity": "sha512-s5d2VtMySvff0UgqkJ0BMCr1es+qREE194EAodGIefq518W53ifvv69e80l9e2MrYJEqUUKwukE/w3H9o15YEw==",
 			"dev": true,
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",
@@ -131,7 +445,7 @@
 				"unzipper": "^0.10.11"
 			},
 			"engines": {
-				"node": ">=8.9.3"
+				"node": ">=16"
 			}
 		},
 		"node_modules/agent-base": {
@@ -307,14 +621,14 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
+				"deep-eql": "^4.1.2",
 				"get-func-name": "^2.0.0",
 				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
@@ -470,15 +784,15 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=6"
 			}
 		},
 		"node_modules/diff": {
@@ -506,9 +820,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
-			"integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
+			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -518,348 +832,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.12",
-				"@esbuild/linux-loong64": "0.15.12",
-				"esbuild-android-64": "0.15.12",
-				"esbuild-android-arm64": "0.15.12",
-				"esbuild-darwin-64": "0.15.12",
-				"esbuild-darwin-arm64": "0.15.12",
-				"esbuild-freebsd-64": "0.15.12",
-				"esbuild-freebsd-arm64": "0.15.12",
-				"esbuild-linux-32": "0.15.12",
-				"esbuild-linux-64": "0.15.12",
-				"esbuild-linux-arm": "0.15.12",
-				"esbuild-linux-arm64": "0.15.12",
-				"esbuild-linux-mips64le": "0.15.12",
-				"esbuild-linux-ppc64le": "0.15.12",
-				"esbuild-linux-riscv64": "0.15.12",
-				"esbuild-linux-s390x": "0.15.12",
-				"esbuild-netbsd-64": "0.15.12",
-				"esbuild-openbsd-64": "0.15.12",
-				"esbuild-sunos-64": "0.15.12",
-				"esbuild-windows-32": "0.15.12",
-				"esbuild-windows-64": "0.15.12",
-				"esbuild-windows-arm64": "0.15.12"
-			}
-		},
-		"node_modules/esbuild-android-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
-			"integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
-			"integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
-			"integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
-			"integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
-			"integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
-			"integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
-			"integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
-			"integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
-			"integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
-			"integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
-			"integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
-			"integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
-			"integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-s390x": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
-			"integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-netbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
-			"integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
-			"integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
-			"integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
-			"integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
-			"integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
-			"integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
+				"@esbuild/android-arm": "0.17.3",
+				"@esbuild/android-arm64": "0.17.3",
+				"@esbuild/android-x64": "0.17.3",
+				"@esbuild/darwin-arm64": "0.17.3",
+				"@esbuild/darwin-x64": "0.17.3",
+				"@esbuild/freebsd-arm64": "0.17.3",
+				"@esbuild/freebsd-x64": "0.17.3",
+				"@esbuild/linux-arm": "0.17.3",
+				"@esbuild/linux-arm64": "0.17.3",
+				"@esbuild/linux-ia32": "0.17.3",
+				"@esbuild/linux-loong64": "0.17.3",
+				"@esbuild/linux-mips64el": "0.17.3",
+				"@esbuild/linux-ppc64": "0.17.3",
+				"@esbuild/linux-riscv64": "0.17.3",
+				"@esbuild/linux-s390x": "0.17.3",
+				"@esbuild/linux-x64": "0.17.3",
+				"@esbuild/netbsd-x64": "0.17.3",
+				"@esbuild/openbsd-x64": "0.17.3",
+				"@esbuild/sunos-x64": "0.17.3",
+				"@esbuild/win32-arm64": "0.17.3",
+				"@esbuild/win32-ia32": "0.17.3",
+				"@esbuild/win32-x64": "0.17.3"
 			}
 		},
 		"node_modules/escalade": {
@@ -1284,12 +1278,11 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-			"integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
 			"dev": true,
 			"dependencies": {
-				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.3",
@@ -1669,9 +1662,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -1790,15 +1783,15 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -1880,16 +1873,156 @@
 	},
 	"dependencies": {
 		"@esbuild/android-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
-			"integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
+			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
+			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
+			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
+			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
+			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
+			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
+			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
+			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
+			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
+			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
-			"integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
+			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
+			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
+			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
+			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
+			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
+			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
+			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
+			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
+			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
+			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
+			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
 			"dev": true,
 			"optional": true
 		},
@@ -1900,33 +2033,27 @@
 			"dev": true
 		},
 		"@types/chai": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-			"integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+			"integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.16",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-			"integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.66.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
-			"integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
-			"dev": true
-		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@vscode/debugadapter": {
@@ -1943,9 +2070,9 @@
 			"integrity": "sha512-tEOY1KxSACd77JFfoipYvLZdVdrTnXBiVgS7zKDmAQxxmVsKPERB6HOXDijoWi1wUjFx+K7plXCtweX+k5Fc/g=="
 		},
 		"@vscode/test-electron": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
-			"integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.2.tgz",
+			"integrity": "sha512-s5d2VtMySvff0UgqkJ0BMCr1es+qREE194EAodGIefq518W53ifvv69e80l9e2MrYJEqUUKwukE/w3H9o15YEw==",
 			"dev": true,
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
@@ -2082,14 +2209,14 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
+				"deep-eql": "^4.1.2",
 				"get-func-name": "^2.0.0",
 				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
@@ -2201,9 +2328,9 @@
 			"dev": true
 		},
 		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "^4.0.0"
@@ -2231,174 +2358,34 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
-			"integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
+			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
 			"dev": true,
 			"requires": {
-				"@esbuild/android-arm": "0.15.12",
-				"@esbuild/linux-loong64": "0.15.12",
-				"esbuild-android-64": "0.15.12",
-				"esbuild-android-arm64": "0.15.12",
-				"esbuild-darwin-64": "0.15.12",
-				"esbuild-darwin-arm64": "0.15.12",
-				"esbuild-freebsd-64": "0.15.12",
-				"esbuild-freebsd-arm64": "0.15.12",
-				"esbuild-linux-32": "0.15.12",
-				"esbuild-linux-64": "0.15.12",
-				"esbuild-linux-arm": "0.15.12",
-				"esbuild-linux-arm64": "0.15.12",
-				"esbuild-linux-mips64le": "0.15.12",
-				"esbuild-linux-ppc64le": "0.15.12",
-				"esbuild-linux-riscv64": "0.15.12",
-				"esbuild-linux-s390x": "0.15.12",
-				"esbuild-netbsd-64": "0.15.12",
-				"esbuild-openbsd-64": "0.15.12",
-				"esbuild-sunos-64": "0.15.12",
-				"esbuild-windows-32": "0.15.12",
-				"esbuild-windows-64": "0.15.12",
-				"esbuild-windows-arm64": "0.15.12"
+				"@esbuild/android-arm": "0.17.3",
+				"@esbuild/android-arm64": "0.17.3",
+				"@esbuild/android-x64": "0.17.3",
+				"@esbuild/darwin-arm64": "0.17.3",
+				"@esbuild/darwin-x64": "0.17.3",
+				"@esbuild/freebsd-arm64": "0.17.3",
+				"@esbuild/freebsd-x64": "0.17.3",
+				"@esbuild/linux-arm": "0.17.3",
+				"@esbuild/linux-arm64": "0.17.3",
+				"@esbuild/linux-ia32": "0.17.3",
+				"@esbuild/linux-loong64": "0.17.3",
+				"@esbuild/linux-mips64el": "0.17.3",
+				"@esbuild/linux-ppc64": "0.17.3",
+				"@esbuild/linux-riscv64": "0.17.3",
+				"@esbuild/linux-s390x": "0.17.3",
+				"@esbuild/linux-x64": "0.17.3",
+				"@esbuild/netbsd-x64": "0.17.3",
+				"@esbuild/openbsd-x64": "0.17.3",
+				"@esbuild/sunos-x64": "0.17.3",
+				"@esbuild/win32-arm64": "0.17.3",
+				"@esbuild/win32-ia32": "0.17.3",
+				"@esbuild/win32-x64": "0.17.3"
 			}
-		},
-		"esbuild-android-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
-			"integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
-			"integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
-			"integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
-			"integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
-			"integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
-			"integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
-			"integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
-			"integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
-			"integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
-			"integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
-			"integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
-			"integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
-			"integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
-			"integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
-			"integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
-			"integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
-			"integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
-			"integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
-			"integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.15.12",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
-			"integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
-			"dev": true,
-			"optional": true
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -2714,12 +2701,11 @@
 			}
 		},
 		"mocha": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-			"integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
 			"dev": true,
 			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.3",
@@ -2991,9 +2977,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true
 		},
 		"unzipper": {
@@ -3092,9 +3078,9 @@
 			"dev": true
 		},
 		"ws": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
 			"requires": {}
 		},
 		"y18n": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
 	"activationEvents": [
 		"onLanguage:SOMns",
 		"onLanguage:SOM",
-		"onLanguage:simple"
+		"onLanguage:simple",
+		"onCommand:extension.effortless-language-servers.runEditorContents",
+		"onCommand:extension.effortless-language-servers.debugEditorContents"
 	],
 	"main": "./out/main",
 	"icon": "resources/logo.png",
@@ -90,6 +92,11 @@
 					"type": "string",
 					"default": null,
 					"description": "Path to the Java 17 or later installation. On macOS, it might be /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home. On Linux perhaps /usr/lib/jvm/java-17-openjdk-amd64"
+				},
+				"els.somnsExecutable": {
+					"type": "string",
+					"default": null,
+					"description": "Absolute path to the SOMns launcher to be used for debugging and executing programs."
 				}
 			}
 		},
@@ -97,8 +104,6 @@
 			{
 				"type": "SOMns",
 				"label": "SOMns",
-				"program": "./out/src/debugger.js",
-				"runtime": "node",
 				"configurationAttributes": {
 					"launch": {
 						"required": [
@@ -180,6 +185,46 @@
 						"tracePort": 7978
 					}
 				]
+			}
+		],
+		"menus": {
+			"editor/title/run": [
+				{
+					"command": "extension.effortless-language-servers.runEditorContents",
+					"when": "resourceLangId == SOMns",
+					"group": "navigation@1"
+				},
+				{
+					"command": "extension.effortless-language-servers.debugEditorContents",
+					"when": "resourceLangId == SOMns",
+					"group": "navigation@2"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "extension.effortless-language-servers.debugEditorContents",
+					"when": "resourceLangId == SOMns"
+				},
+				{
+					"command": "extension.effortless-language-servers.runEditorContents",
+					"when": "resourceLangId == SOMns"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "extension.effortless-language-servers.debugEditorContents",
+				"title": "Debug File",
+				"category": "SOMns Debug",
+				"enablement": "!inDebugMode",
+				"icon": "$(debug-alt)"
+			},
+			{
+				"command": "extension.effortless-language-servers.runEditorContents",
+				"title": "Run File",
+				"category": "SOMns Debug",
+				"enablement": "!inDebugMode",
+				"icon": "$(play)"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"version": "0.8.1",
 	"publisher": "MetaConcProject",
 	"engines": {
-		"vscode": "^1.66.0"
+		"vscode": "^1.74.0"
 	},
 	"categories": [
 		"Debuggers",
@@ -241,22 +241,22 @@
 		"create-server-shell-script": "npx run-func out/src/command-line.js getShellScript false false > out/server/start.sh; chmod +x out/server/start.sh"
 	},
 	"devDependencies": {
-		"@types/chai": "4.3.3",
-		"@types/mocha": "9.1.1",
-		"@types/node": "18.7.16",
-		"@types/vscode": "1.66.0",
-		"@vscode/test-electron": "2.1.5",
-		"chai": "4.3.6",
-		"esbuild": "^0.15.12",
-		"mocha": "10.0.0",
+		"@types/chai": "4.3.4",
+		"@types/mocha": "10.0.1",
+		"@types/node": "18.11.18",
+		"@types/vscode": "1.74.0",
+		"@vscode/test-electron": "2.2.2",
+		"chai": "4.3.7",
+		"esbuild": "0.17.3",
+		"mocha": "10.2.0",
 		"run-func": "3.0.0",
-		"typescript": "4.8.2"
+		"typescript": "4.9.4"
 	},
 	"dependencies": {
 		"@vscode/debugadapter": "1.55.1",
 		"@vscode/debugprotocol": "1.55.1",
 		"vscode-languageclient": "7.0.0",
 		"vscode-languageserver-protocol": "3.16.0",
-		"ws": "8.8.1"
+		"ws": "8.12.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -97,11 +97,6 @@
 			{
 				"type": "SOMns",
 				"label": "SOMns",
-				"enableBreakpointsFor": {
-					"languageIds": [
-						"SOMns"
-					]
-				},
 				"program": "./out/src/debugger.js",
 				"runtime": "node",
 				"configurationAttributes": {

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
 		"pretest": "npm run compile",
 		"watch": "tsc --build --watch",
 		"compile": "tsc --build && cp -R test/examples out/test/",
+		"prerun": "npm run compile && npm run esbuild-base -- --sourcemap",
 		"postinstall": "npm run compile:server",
 		"test": "node ./out/test/runTest.js",
 		"create-server-shell-script": "npx run-func out/src/command-line.js getShellScript false false > out/server/start.sh; chmod +x out/server/start.sh"

--- a/src/debugger-config.ts
+++ b/src/debugger-config.ts
@@ -1,0 +1,99 @@
+import {
+  CancellationToken,
+  commands,
+  debug,
+  DebugAdapterDescriptor,
+  DebugAdapterDescriptorFactory,
+  DebugAdapterInlineImplementation,
+  DebugConfiguration,
+  DebugConfigurationProvider,
+  DebugSession,
+  ExtensionContext,
+  ProviderResult,
+  Uri,
+  window,
+  workspace,
+  WorkspaceFolder
+} from "vscode";
+import { SomDebugSession } from "./debugger";
+
+const configuration = workspace.getConfiguration('els');
+
+/**
+ * This SOMnsConfigurationProvider is a dynamic provider that can change the debug configuration parameters
+ */
+class SOMnsConfigurationProvider implements DebugConfigurationProvider {
+
+	/** Resolve the debug configuration to debug currently selected file */
+	resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+		// retrieve the active file, if it is a SOMns file then substitute the program variable with the file path
+		const editor = window.activeTextEditor;
+		if (editor && editor.document.languageId === 'SOMns') {
+      if (!config.runtime) {
+        const somNsExecutable = configuration.get('somnsExecutable');
+        if (!somNsExecutable) {
+          window.showErrorMessage('SOMns was not found. Please configure it in the settings under the `els.somnsExecutable` key.');
+          return null;
+        } else {
+          config.runtime = somNsExecutable;
+        }
+      }
+			if (!config.program) {
+				config.program = '${file}';
+				config.stopOnEntry = true;
+			}
+		}
+
+		return config;
+	}
+}
+
+class InlineDebugAdapterFactory implements DebugAdapterDescriptorFactory {
+
+	createDebugAdapterDescriptor(_session: DebugSession): ProviderResult<DebugAdapterDescriptor> {
+		return new DebugAdapterInlineImplementation(new SomDebugSession());
+	}
+}
+
+export function activateDebuggerFeatures(context: ExtensionContext) {
+  const configProvider = debug.registerDebugConfigurationProvider('SOMns', new SOMnsConfigurationProvider);
+
+  // Registering the configuration provider for starting opened file
+	const runEditor = commands.registerCommand('extension.effortless-language-servers.runEditorContents', (resource: Uri) => {
+		let targetResource = resource;
+			if (!targetResource && window.activeTextEditor) {
+				targetResource = window.activeTextEditor.document.uri;
+			}
+			if (targetResource) {
+				debug.startDebugging(undefined, {
+            type: 'SOMns',
+            name: 'Run File',
+            request: 'launch',
+            program: targetResource.fsPath
+          },
+					{ noDebug: true }
+				);
+			}
+	});
+
+	const debugEditor = commands.registerCommand('extension.effortless-language-servers.debugEditorContents', (resource: Uri) => {
+		let targetResource = resource;
+		if (!targetResource && window.activeTextEditor) {
+			targetResource = window.activeTextEditor.document.uri;
+		}
+		if (targetResource) {
+			debug.startDebugging(undefined, {
+				type: 'SOMns',
+				name: 'Debug File',
+				request: 'launch',
+				program: targetResource.fsPath,
+				stopOnEntry: true
+			});
+		}
+	});
+
+  const adapterFactory = new InlineDebugAdapterFactory();
+	const debugAdapterFactory = debug.registerDebugAdapterDescriptorFactory('SOMns', adapterFactory);
+
+  context.subscriptions.push(configProvider, runEditor, debugEditor, debugAdapterFactory);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,19 +12,19 @@ const LSPort = 8123;  // TODO: make configurable
 
 const configuration = workspace.getConfiguration('els');
 const EnableExtensionDebugging : boolean = <boolean> configuration.get('debugMode');
-const JavaHomeConfig = configuration.get('javaHome');
 
 export const CLIENT_OPTION: LanguageClientOptions = {
 	documentSelector: ['SOMns', 'SOM','simple']
 }
 
 type PathConverter = (path: string) => string;
-let client: LanguageClient = null;
+
+let client: LanguageClient = null;
 let serverProcess: ChildProcess = null;
 
 function getServerOptions(asAbsolutePath: PathConverter, enableDebug:
 	  boolean, enableTcp: boolean): ServerOptions {
-	const cmdLine = getCommandLine(JavaHomeConfig, asAbsolutePath, enableDebug, enableTcp);
+	const cmdLine = getCommandLine(configuration.get('javaHome'), asAbsolutePath, enableDebug, enableTcp);
 
 	return {
 		run:   cmdLine,
@@ -110,10 +110,10 @@ export function activate(context: ExtensionContext) {
 				window.showInformationMessage("SOMns Debug Mode: Trying to connect to Language Server on port " + LSPort);
 				connectToLanguageServer(resolve, reject);
 			} else {
-				if (!isJavaAvailableAndCompatible(JavaHomeConfig)) {
+				if (!isJavaAvailableAndCompatible(configuration.get('javaHome'))) {
 					window.showErrorMessage('Java 17 or new was not found. Please configure it in the settings under the `els.javaHome` key.');
 				}
-				window.showInformationMessage("SOMns Starting Language Server");
+				// window.showInformationMessage("SOMns Starting Language Server");
 				startLanguageServer(context.asAbsolutePath, resolve, reject);
 			}
 		});


### PR DESCRIPTION
The main reason for this PR is to move the implementation of our SOMns debugging adapter to use the in-process support.
Before this PR, the `debugger.ts` would be run in a separate process, which makes debugging unintuitive. (Though, there was a special launch configuration, which would have launch the debugger adapter in a way it can be debugged. This is also deleted by this PR.)

In addition, we now have a run and debug button directly on the file tab.

Minor changes:

- make sure we run the prerun target before debugging the extension, and that we have sourcemaps
- introduce the `els.somnsExecutable` configuration key to point to the SOMns executable
- move all debugger configuration and launching code into the `debugger-config.ts`
- fix the import of WebSocket since it seems to be crashing inside of VSCode
- simple running of programs doesn’t need the `-wd` flag